### PR TITLE
fix: correctly print words in brackets in descriptions

### DIFF
--- a/src/halper/commands/edit_description.py
+++ b/src/halper/commands/edit_description.py
@@ -16,11 +16,14 @@ def edit_command_description(command_id: int) -> None:
         raise typer.Exit(code=1)
 
     console.print(f"Editing description for command [code]{command.name}[/code]")
-    console.print(f"Current description: [code]{command.description}[/code]")
+    console.print(f"Current description: [code]{command.escaped_desc}[/code]")
     console.rule()
     new_description = Prompt.ask("New description")
 
-    confirm = Prompt.ask(f"Set description to [code]{new_description}[/code]?", choices=["y", "n"])
+    new_description_display = new_description.replace("[", "\\[")
+    confirm = Prompt.ask(
+        f"Set description to [code]{new_description_display}[/code]?", choices=["y", "n"]
+    )
     if confirm.lower() == "n":
         raise typer.Abort()
 

--- a/src/halper/models/database.py
+++ b/src/halper/models/database.py
@@ -82,6 +82,11 @@ class Command(BaseModel):
         )
 
     @property
+    def escaped_desc(self) -> str:
+        """Return escaped description."""
+        return self.description.replace("[", "\\[")
+
+    @property
     def category_names(self) -> list[str]:
         """Return a list of category names associated with this command.
 
@@ -122,7 +127,7 @@ class Command(BaseModel):
         grid.add_row("Command:", f"[bold]{self.name}[/bold]")
         if show_id:
             grid.add_row("ID:", f"[cyan]{self.id!s}[/cyan]")
-        grid.add_row("Description:", self.description)
+        grid.add_row("Description:", self.escaped_desc)
         grid.add_row("Categories:", ", ".join(self.category_names))
         grid.add_row("Type:", self.command_type.title())
         grid.add_row("File:", f"[dim]{self.file.path}[/dim]")

--- a/src/halper/views/views.py
+++ b/src/halper/views/views.py
@@ -126,7 +126,7 @@ def command_list_table(  # noqa: PLR0917
             continue
 
         description = (
-            c.description
+            c.escaped_desc
             if c.description
             else c.code_syntax()
             if c.command_type in {CommandType.ALIAS.name, CommandType.EXPORT.name}

--- a/tests/text_parser_test.py
+++ b/tests/text_parser_test.py
@@ -37,7 +37,7 @@ export TEXT="two" # comment inline
         echo "Hello World";
     }
 
-    alias ls='two' # comment inline
+    alias ls='two' # comment inline [arg]
 
 function three() {echo "Hello World"; }
 
@@ -67,8 +67,8 @@ Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor 
         ),
         (
             "best",
-            "alias ls='ls -l' # comment is here\n",
-            {"name": "ls", "code": "ls -l", "description": "comment is here"},
+            "alias ls='ls -l' # comment is [here]\n",
+            {"name": "ls", "code": "ls -l", "description": "comment is [here]"},
         ),
         (
             "best",
@@ -505,7 +505,7 @@ def test_parse_file(mock_specific_config) -> None:
             {
                 "name": "ls",
                 "code": "two",
-                "description": "comment inline",
+                "description": "comment inline [arg]",
                 "command_type": CommandType.ALIAS,
             },
             {


### PR DESCRIPTION
The Python Rich Console library strips words in brackets when printing. This commit escapes brackets in command descriptions to ensure they are displayed to the user.